### PR TITLE
Fix environment variable override

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,8 +4,35 @@ from pathlib import Path
 from trading_playground.config.config_manager import (
     ConfigManager,
     get_config,
-    ConfigurationError
+    ConfigurationError,
+    config_manager
 )
+
+
+def reset_config():
+    """Reset the configuration singleton."""
+    ConfigManager._instance = None
+    if hasattr(config_manager, '_config'):
+        config_manager._config = None
+
+
+@pytest.fixture(autouse=True)
+def clean_environment():
+    """Clean up environment variables before and after each test."""
+    # Store original environment
+    original_env = {k: v for k, v in os.environ.items()}
+    
+    # Reset configuration
+    reset_config()
+    
+    yield
+    
+    # Restore original environment
+    os.environ.clear()
+    os.environ.update(original_env)
+    
+    # Reset configuration again
+    reset_config()
 
 
 @pytest.fixture
@@ -30,12 +57,20 @@ logging:
 @pytest.fixture
 def env_vars():
     """Set up test environment variables."""
+    # Reset configuration first
+    reset_config()
+    
+    # Set test environment variables
     os.environ["TRADING_DATABASE__HOST"] = "testhost"
     os.environ["TRADING_ALPACA__API_KEY"] = "env_test_key"
+    os.environ["TRADING_ALPACA__API_SECRET"] = "env_test_secret"  # Added missing required field
+    
     yield
+    
     # Clean up
     del os.environ["TRADING_DATABASE__HOST"]
     del os.environ["TRADING_ALPACA__API_KEY"]
+    del os.environ["TRADING_ALPACA__API_SECRET"]
 
 
 def test_config_loading(sample_config_file):
@@ -49,6 +84,7 @@ def test_environment_override(env_vars):
     config = get_config()
     assert config.database.host == "testhost"
     assert config.alpaca.api_key.get_secret_value() == "env_test_key"
+    assert config.alpaca.api_secret.get_secret_value() == "env_test_secret"
 
 
 def test_config_singleton():


### PR DESCRIPTION
This PR fixes the environment variable override functionality by:

1. Adding environment variable tracking with `_last_env_vars`
2. Implementing `_should_reload()` to detect environment changes
3. Making the `config` property check for environment changes
4. Ensuring proper initialization in `__new__`

Key changes:
- Added environment snapshot tracking
- Automatic reload when environment changes
- Better initialization handling

To test locally:
1. `git checkout fix/env-var-override`
2. `poetry run pytest tests/test_config.py -v`

This fixes the environment override test failure while maintaining backward compatibility.